### PR TITLE
Fix invalid price

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -12,6 +12,6 @@ class Item extends Model
 
     public function getTotalAttribute()
     {
-        return $this->price * $this->quantity;
+        return $this->price;
     }
 }

--- a/tests/Model/BillingTest.php
+++ b/tests/Model/BillingTest.php
@@ -39,7 +39,7 @@ class BillingTest extends TestCase
         $this->expectDeprecationMessage('Item must be instance of ' . Item::class);
         $item = Item::make([
             'name' => 'Token PLN',
-            'price' => 1000,
+            'price' => 20000,
             'quantity' => 20,
         ]);
         Billing::make([
@@ -58,7 +58,7 @@ class BillingTest extends TestCase
         $items = [
             Item::make([
                 'name' => 'Sandal Jepit',
-                'price' => 10000,
+                'price' => 20000,
                 'quantity' => 2,
             ]),
             Item::make([

--- a/tests/Model/ItemTest.php
+++ b/tests/Model/ItemTest.php
@@ -33,16 +33,16 @@ class ItemTest extends TestCase
     {
         $item = Item::make([
             'name' => 'Token PLN',
-            'price' => 1000,
+            'price' => 20000,
             'quantity' => 20,
         ]);
         $this->assertSame('Token PLN', $item->name);
-        $this->assertSame(1000, $item->price);
+        $this->assertSame(20000, $item->price);
         $this->assertSame(20, $item->quantity);
         $this->assertSame(20000, $item->total);
         $item->price = 2000;
         $this->assertSame(2000, $item->price);
-        $this->assertSame(40000, $item->total);
+        $this->assertSame(2000, $item->total);
         $this->assertSame(null, $item->prince);
     }
 }


### PR DESCRIPTION
The total price of an item is wrong.

On the `SemarangDev\Duitku\Model\Item` class it is like this:

```php
public function getTotalAttribute()
{
    return $this->price * $this->quantity;
}
```

but after testing my self and look up to duitku api docs [here](https://docs.duitku.com/api/id/#request-parameters) and [here](https://docs.duitku.com/api/id/#json-object).  
The price is already the total price. So there is no need to multiply it by its quantity.

![image](https://user-images.githubusercontent.com/20186786/111497470-b6098c80-8773-11eb-9d16-8b97b3f15e4a.png)

See above at `paymentAmount` and `itemDetails`.

This PR fixed that.